### PR TITLE
CB-9193: Add 'showLibraryButton' to allow choosing source

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Can only return photos as base64-encoded image.
 
 #### Firefox OS Quirks
 
-Camera plugin is currently implemented using [Web Activities](https://hacks.mozilla.org/2013/01/introducing-web-activities/). 
+Camera plugin is currently implemented using [Web Activities](https://hacks.mozilla.org/2013/01/introducing-web-activities/).
 
 #### iOS Quirks
 
@@ -188,7 +188,8 @@ Optional parameters to customize the camera settings.
       targetWidth: 100,
       targetHeight: 100,
       popoverOptions: CameraPopoverOptions,
-      saveToPhotoAlbum: false };
+      saveToPhotoAlbum: false,
+      showLibraryButton: false };
 
 - __quality__: Quality of the saved image, expressed as a range of 0-100, where 100 is typically full resolution with no loss from file compression. The default is 50. _(Number)_ (Note that information about the camera's resolution is unavailable.)
 
@@ -242,11 +243,15 @@ Optional parameters to customize the camera settings.
             FRONT : 1      // Use the front-facing camera
         };
 
+- __showLibraryButton__: When `sourceType` is `Camera.PictureSourceType.CAMERA`, this provides a way for the user to choose whether they want to capture the picture from the camera or select from the library. The behavior varies slightly based on the device, as not all devices provide a clean way to do this with their default applications. See the Quirks section below for details on platform-specific behaviors.
+
 #### Amazon Fire OS Quirks
 
 - Any `cameraDirection` value results in a back-facing photo.
 
 - Ignores the `allowEdit` parameter.
+
+- Ignores the `showLibraryButton` parameter.
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
 
@@ -254,10 +259,12 @@ Optional parameters to customize the camera settings.
 
 - Any `cameraDirection` value results in a back-facing photo.
 
-- Android also uses the Crop Activity for allowEdit, even though crop should work and actually pass the cropped image back to Cordova, the only one that works consistently is the one bundled 
+- Android also uses the Crop Activity for allowEdit, even though crop should work and actually pass the cropped image back to Cordova, the only one that works consistently is the one bundled
 with the Google Plus Photos application.  Other crops may not work.
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
+
+- When `showLibraryButton` is `true`, an Intent chooser is displayed which lists all possible handlers for either the Camera or File chooser -- and the user can then pick which method they would prefer to use to capture the image.
 
 #### BlackBerry 10 Quirks
 
@@ -270,6 +277,8 @@ with the Google Plus Photos application.  Other crops may not work.
 - Ignores the `correctOrientation` parameter.
 
 - Ignores the `cameraDirection` parameter.
+
+- Ignores the `showLibraryButton` parameter.
 
 #### Firefox OS Quirks
 
@@ -291,11 +300,15 @@ with the Google Plus Photos application.  Other crops may not work.
 
 - Ignores the `cameraDirection` parameter.
 
+- Ignores the `showLibraryButton` parameter.
+
 #### iOS Quirks
 
 - Set `quality` below 50 to avoid memory errors on some devices.
 
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
+
+- `showLibraryButton` adds a `Library` button to the default camera controls. For iPhone, this is on the lower right. For iPad, this is halfway between the shutter and `Cancel` buttons. The button is shown as the text `Library`, unless the app has access to the photo library already, in which case a thumbnail of the most recent image is provided. This is only supported on iOS 7+.
 
 #### Tizen Quirks
 
@@ -316,6 +329,7 @@ You may also comment or up-vote the related issue in the [issue tracker](https:/
 
 - Ignores the `mediaType` property of `cameraOptions` as the Windows Phone SDK does not provide a way to choose videos from PHOTOLIBRARY.
 
+- `showLibraryButton` launches directly into the photo chooser task, and provides a camera button at the bottom to allow the user to toggle over into the camera.
 
 ## CameraError
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -50,12 +50,12 @@
             <feature name="Camera">
                 <param name="firefoxos-package" value="Camera" />
             </feature>
-        </config-file>                                         
-        
+        </config-file>
+
         <js-module src="src/firefoxos/CameraProxy.js" name="CameraProxy">
           <runs />
         </js-module>
-    </platform>  
+    </platform>
 
     <!-- android -->
     <platform name="android">
@@ -76,6 +76,12 @@
             <clobbers target="CameraPopoverHandle" />
         </js-module>
 
+        <config-file target="res/values/strings.xml" parent="/resources">
+            <string name="plugin_camera_source_chooser">"Select Source"</string>
+            <string name="plugin_camera_get_picture">Get Picture</string>
+            <string name="plugin_camera_get_video">Get Video</string>
+            <string name="plugin_camera_get_all">Get All</string>
+        </config-file>
      </platform>
 
     <!-- amazon-fireos -->
@@ -98,7 +104,7 @@
         </js-module>
 
      </platform>
-     
+
      <!-- ubuntu -->
      <platform name="ubuntu">
          <config-file target="config.xml" parent="/*">
@@ -147,11 +153,11 @@
          <framework src="MobileCoreServices.framework" />
          <framework src="CoreGraphics.framework" />
          <framework src="AVFoundation.framework" />
-         
+
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string></string>
          </config-file>
-                  
+
      </platform>
 
     <!-- blackberry10 -->

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -28,7 +28,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -39,8 +41,10 @@ import org.json.JSONException;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 import android.content.ContentValues;
 import android.content.Intent;
+import android.content.pm.ResolveInfo;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
@@ -51,6 +55,7 @@ import android.media.MediaScannerConnection.MediaScannerConnectionClient;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Parcelable;
 import android.provider.MediaStore;
 import android.util.Base64;
 import android.util.Log;
@@ -76,14 +81,12 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     private static final int JPEG = 0;                  // Take a picture of type JPEG
     private static final int PNG = 1;                   // Take a picture of type PNG
-    private static final String GET_PICTURE = "Get Picture";
-    private static final String GET_VIDEO = "Get Video";
-    private static final String GET_All = "Get All";
-    
+
     private static final String LOG_TAG = "CameraLauncher";
 
     //Where did this come from?
     private static final int CROP_CAMERA = 100;
+    private static final int SOURCE_CHOOSER = 200;
 
     private int mQuality;                   // Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
     private int targetWidth;                // desired width of the image
@@ -95,6 +98,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private boolean correctOrientation;     // Should the pictures orientation be corrected
     private boolean orientationCorrected;   // Has the picture's orientation been corrected
     private boolean allowEdit;              // Should we allow the user to crop the image.
+    private boolean showLibraryButton;      // Should we allow the user to choose from the library as well as the camera.
 
     public CallbackContext callbackContext;
     private int numPics;
@@ -115,25 +119,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         this.callbackContext = callbackContext;
 
         if (action.equals("takePicture")) {
-            int srcType = CAMERA;
-            int destType = FILE_URI;
-            this.saveToPhotoAlbum = false;
-            this.targetHeight = 0;
-            this.targetWidth = 0;
-            this.encodingType = JPEG;
-            this.mediaType = PICTURE;
-            this.mQuality = 80;
+            int srcType = args.optInt(2, CAMERA);
+            int destType = args.optInt(1, FILE_URI);
 
-            this.mQuality = args.getInt(0);
-            destType = args.getInt(1);
-            srcType = args.getInt(2);
-            this.targetWidth = args.getInt(3);
-            this.targetHeight = args.getInt(4);
-            this.encodingType = args.getInt(5);
-            this.mediaType = args.getInt(6);
-            this.allowEdit = args.getBoolean(7);
-            this.correctOrientation = args.getBoolean(8);
-            this.saveToPhotoAlbum = args.getBoolean(9);
+            // Process the rest of the configuration arguments
+            processConfiguration(args);
 
             // If the user specifies a 0 or smaller width/height
             // make it -1 so later comparisons succeed
@@ -146,7 +136,12 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
              try {
                 if (srcType == CAMERA) {
-                    this.takePicture(destType, encodingType);
+                    if (this.showLibraryButton == true) {
+                        this.showIntentChooser(destType, encodingType);
+                    }
+                    else {
+                        this.takePicture(destType, encodingType);
+                    }
                 }
                 else if ((srcType == PHOTOLIBRARY) || (srcType == SAVEDPHOTOALBUM)) {
                     this.getImage(srcType, destType, encodingType);
@@ -159,11 +154,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 callbackContext.sendPluginResult(r);
                 return true;
             }
-             
+
             PluginResult r = new PluginResult(PluginResult.Status.NO_RESULT);
             r.setKeepCallback(true);
             callbackContext.sendPluginResult(r);
-            
+
             return true;
         }
         return false;
@@ -172,6 +167,23 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     //--------------------------------------------------------------------------
     // LOCAL METHODS
     //--------------------------------------------------------------------------
+
+    private void processConfiguration(JSONArray args) throws JSONException {
+        if (args == null) {
+            throw new JSONException("no configuration object passed");
+        }
+
+        this.mQuality = args.optInt(0, 80);
+        // args 1 and 2 (destType, srcType) are skipped because they have no field representation in this class
+        this.targetWidth = args.optInt(3, 0);
+        this.targetHeight = args.optInt(4, 0);
+        this.encodingType = args.optInt(5, JPEG);
+        this.mediaType = args.optInt(6, PICTURE);
+        this.allowEdit = args.optBoolean(7, false);
+        this.correctOrientation = args.optBoolean(8, false);
+        this.saveToPhotoAlbum = args.optBoolean(9, false);
+        this.showLibraryButton = args.optBoolean(12, false);
+    }
 
     private String getTempDirectoryPath() {
         File cache = null;
@@ -192,6 +204,121 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     }
 
     /**
+     * Helper to retrieve a string from the resources.
+     *
+     * @param resourceName      The name of the string resource to load.
+     */
+    private String getStringResource(String resourceName) {
+        android.content.res.Resources activityRes = cordova.getActivity().getResources();
+        int stringResId = activityRes.getIdentifier(resourceName, "string", cordova.getActivity().getPackageName());
+        return activityRes.getString(stringResId);
+    }
+
+    /**
+     * Shows an Intent chooser with all camera and gallery options, so the
+     * user can choose which method they want to use to retrieve the image.
+     *
+     * @param returnType        The expected return type of the file.
+     * @param encodingType      Set the encoding of image to return.
+     */
+    public void showIntentChooser(int returnType, int encodingType) {
+        if (this.cordova == null) return;
+
+        final PackageManager mPm = this.cordova.getActivity().getPackageManager();
+
+        // Store the Camera Intents
+        final Intent captureIntent = getCameraIntent(encodingType);
+        final List<Intent> cameraIntents = new ArrayList<Intent>();
+
+        // Use the Intent to find all apps that support it
+        final List<ResolveInfo> cameraResolveInfoList = mPm.queryIntentActivities(captureIntent, 0);
+        for(ResolveInfo res : cameraResolveInfoList) {
+            // Create an intent with the specific camera app
+            final Intent intent = new Intent(captureIntent);
+            intent.setComponent(new ComponentName(res.activityInfo.packageName, res.activityInfo.name));
+            intent.setPackage(res.activityInfo.packageName);
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, this.imageUri);
+            cameraIntents.add(intent);
+        }
+
+        // Store the Gallery intents
+        final Intent galleryIntent = getGalleryIntent(encodingType);
+
+        // Create a chooser Intent to allow the user to pick
+        final Intent chooserIntent = Intent.createChooser(galleryIntent, getStringResource("plugin_camera_source_chooser"));
+
+        // Add the camera intents as extra intents in the chooser
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, cameraIntents.toArray(new Parcelable[cameraIntents.size()]));
+
+        this.cordova.startActivityForResult(this, chooserIntent, SOURCE_CHOOSER + returnType);
+    }
+
+    /**
+     * Returns an Intent to take a picture via the camera.
+     *
+     * @param encodingType      Set the encoding of image to return.
+     */
+    private Intent getCameraIntent(int encodingType) {
+        // Save the number of images currently on disk for later
+        this.numPics = queryImgDB(whichContentStore()).getCount();
+
+        // Let's use the intent and see what happens
+        final Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+
+        // Specify file so that large image is captured and returned
+        final File photo = createCaptureFile(encodingType);
+        this.imageUri = Uri.fromFile(photo);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, this.imageUri);
+
+        return intent;
+    }
+
+    /**
+     * Returns an Intent to retrieve a file from the gallery.
+     *
+     * @param encodingType      Set the encoding of image to return.
+     */
+    private Intent getGalleryIntent(int encodingType) {
+        Intent intent = new Intent();
+        croppedUri = null;
+        if (this.mediaType == PICTURE) {
+            intent.setType("image/*");
+            if (this.allowEdit) {
+                intent.setAction(Intent.ACTION_PICK);
+                intent.putExtra("crop", "true");
+                if (targetWidth > 0) {
+                    intent.putExtra("outputX", targetWidth);
+                }
+                if (targetHeight > 0) {
+                    intent.putExtra("outputY", targetHeight);
+                }
+                if (targetHeight > 0 && targetWidth > 0 && targetWidth == targetHeight) {
+                    intent.putExtra("aspectX", 1);
+                    intent.putExtra("aspectY", 1);
+                }
+                File photo = createCaptureFile(encodingType);
+                croppedUri = Uri.fromFile(photo);
+                intent.putExtra(MediaStore.EXTRA_OUTPUT, croppedUri);
+            } else {
+                intent.setAction(Intent.ACTION_GET_CONTENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+            }
+        } else if (this.mediaType == VIDEO) {
+            intent.setType("video/*");
+            intent.setAction(Intent.ACTION_GET_CONTENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+        } else if (this.mediaType == ALLMEDIA) {
+            // I wanted to make the type 'image/*, video/*' but this does not work on all versions
+            // of android so I had to go with the wildcard search.
+            intent.setType("*/*");
+            intent.setAction(Intent.ACTION_GET_CONTENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+        }
+
+        return intent;
+    }
+
+    /**
      * Take a picture with the camera.
      * When an image is captured or the camera view is cancelled, the result is returned
      * in CordovaActivity.onActivityResult, which forwards the result to this.onActivityResult.
@@ -206,16 +333,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void takePicture(int returnType, int encodingType) {
-        // Save the number of images currently on disk for later
-        this.numPics = queryImgDB(whichContentStore()).getCount();
-
-        // Let's use the intent and see what happens
-        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-
-        // Specify file so that large image is captured and returned
-        File photo = createCaptureFile(encodingType);
-        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, Uri.fromFile(photo));
-        this.imageUri = Uri.fromFile(photo);
+        // Let's get the camera intent
+        Intent intent = getCameraIntent(encodingType);
 
         if (this.cordova != null) {
             // Let's check to make sure the camera is actually installed. (Legacy Nexus 7 code)
@@ -260,101 +379,73 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param quality           Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
      * @param srcType           The album to get image from.
      * @param returnType        Set the type of image to return.
-     * @param encodingType 
+     * @param encodingType
      */
     // TODO: Images selected from SDCARD don't display correctly, but from CAMERA ALBUM do!
     // TODO: Images from kitkat filechooser not going into crop function
     public void getImage(int srcType, int returnType, int encodingType) {
-        Intent intent = new Intent();
-        String title = GET_PICTURE;
-        croppedUri = null;
-        if (this.mediaType == PICTURE) {
-            intent.setType("image/*");
-            if (this.allowEdit) {
-                intent.setAction(Intent.ACTION_PICK);
-                intent.putExtra("crop", "true");
-                if (targetWidth > 0) {
-                    intent.putExtra("outputX", targetWidth);
-                }
-                if (targetHeight > 0) {
-                    intent.putExtra("outputY", targetHeight);
-                }
-                if (targetHeight > 0 && targetWidth > 0 && targetWidth == targetHeight) {
-                    intent.putExtra("aspectX", 1);
-                    intent.putExtra("aspectY", 1);
-                }
-                File photo = createCaptureFile(encodingType);
-                croppedUri = Uri.fromFile(photo);
-                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
-            } else {
-                intent.setAction(Intent.ACTION_GET_CONTENT);
-                intent.addCategory(Intent.CATEGORY_OPENABLE);
-            }
-        } else if (this.mediaType == VIDEO) {
-                intent.setType("video/*");
-                title = GET_VIDEO;
-          intent.setAction(Intent.ACTION_GET_CONTENT);
-          intent.addCategory(Intent.CATEGORY_OPENABLE);
-        } else if (this.mediaType == ALLMEDIA) {
-                // I wanted to make the type 'image/*, video/*' but this does not work on all versions
-                // of android so I had to go with the wildcard search.
-                intent.setType("*/*");
-                title = GET_All;
-          intent.setAction(Intent.ACTION_GET_CONTENT);
-          intent.addCategory(Intent.CATEGORY_OPENABLE);
+        Intent intent = getGalleryIntent(encodingType);
+        String title = getStringResource("plugin_camera_get_picture");
+
+        if (this.mediaType == VIDEO) {
+            title = getStringResource("plugin_camera_get_video");
         }
+        else if (this.mediaType == ALLMEDIA) {
+            title = getStringResource("plugin_camera_get_all");
+        }
+
         if (this.cordova != null) {
             this.cordova.startActivityForResult((CordovaPlugin) this, Intent.createChooser(intent,
                     new String(title)), (srcType + 1) * 16 + returnType + 1);
         }
     }
 
-  /**
-   * Brings up the UI to perform crop on passed image URI
-   * 
-   * @param picUri
-   */
-  private void performCrop(Uri picUri, int destType, Intent cameraIntent) {
-    try {
-      Intent cropIntent = new Intent("com.android.camera.action.CROP");
-      // indicate image type and Uri
-      cropIntent.setDataAndType(picUri, "image/*");
-      // set crop properties
-      cropIntent.putExtra("crop", "true");
+    /**
+    * Brings up the UI to perform crop on passed image URI
+    *
+    * @param picUri
+    */
+    private void performCrop(Uri picUri, int destType, Intent cameraIntent) {
+        try {
+            Intent cropIntent = new Intent("com.android.camera.action.CROP");
+            // indicate image type and Uri
+            cropIntent.setDataAndType(picUri, "image/*");
+            // set crop properties
+            cropIntent.putExtra("crop", "true");
 
-      // indicate output X and Y
-      if (targetWidth > 0) {
-          cropIntent.putExtra("outputX", targetWidth);
-      }
-      if (targetHeight > 0) {
-          cropIntent.putExtra("outputY", targetHeight);
-      }
-      if (targetHeight > 0 && targetWidth > 0 && targetWidth == targetHeight) {
-          cropIntent.putExtra("aspectX", 1);
-          cropIntent.putExtra("aspectY", 1);
-      }
-      // create new file handle to get full resolution crop
-      croppedUri = Uri.fromFile(new File(getTempDirectoryPath(), System.currentTimeMillis() + ".jpg"));
-      cropIntent.putExtra("output", croppedUri);
+            // indicate output X and Y
+            if (targetWidth > 0) {
+                cropIntent.putExtra("outputX", targetWidth);
+            }
+            if (targetHeight > 0) {
+                cropIntent.putExtra("outputY", targetHeight);
+            }
+            if (targetHeight > 0 && targetWidth > 0 && targetWidth == targetHeight) {
+                cropIntent.putExtra("aspectX", 1);
+                cropIntent.putExtra("aspectY", 1);
+            }
+            // create new file handle to get full resolution crop
+            croppedUri = Uri.fromFile(new File(getTempDirectoryPath(), System.currentTimeMillis() + ".jpg"));
+            cropIntent.putExtra("output", croppedUri);
 
-      // start the activity - we handle returning in onActivityResult
+            // start the activity - we handle returning in onActivityResult
 
-      if (this.cordova != null) {
-        this.cordova.startActivityForResult((CordovaPlugin) this,
-            cropIntent, CROP_CAMERA + destType);
-      }
-    } catch (ActivityNotFoundException anfe) {
-      Log.e(LOG_TAG, "Crop operation not supported on this device");
-      try {
-          processResultFromCamera(destType, cameraIntent);
-      }
-      catch (IOException e)
-      {
-          e.printStackTrace();
-          Log.e(LOG_TAG, "Unable to write to file");
-      }
+            if (this.cordova != null) {
+                this.cordova.startActivityForResult((CordovaPlugin) this,
+                    cropIntent, CROP_CAMERA + destType);
+            }
+        } catch (ActivityNotFoundException anfe) {
+            Log.e(LOG_TAG, "Crop operation not supported on this device");
+            try {
+                processResultFromCamera(destType, cameraIntent);
+            }
+            catch (IOException e)
+            {
+                e.printStackTrace();
+                Log.e(LOG_TAG, "Unable to write to file");
+            }
+        }
     }
-  }
 
     /**
      * Applies all needed transformation to the image received from the camera.
@@ -403,7 +494,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 // Try to get the bitmap from intent.
                 bitmap = (Bitmap)intent.getExtras().get("data");
             }
-            
+
             // Double-check the bitmap.
             if (bitmap == null) {
                 Log.d(LOG_TAG, "I either have a null image path or bitmap");
@@ -436,7 +527,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             }
 
             // If all this is true we shouldn't compress the image.
-            if (this.targetHeight == -1 && this.targetWidth == -1 && this.mQuality == 100 && 
+            if (this.targetHeight == -1 && this.targetWidth == -1 && this.mQuality == 100 &&
                     !this.correctOrientation) {
                 writeUncompressedImage(uri);
 
@@ -479,25 +570,25 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         bitmap = null;
     }
 
-private String getPicutresPath()
-{
-    String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-    String imageFileName = "IMG_" + timeStamp + ".jpg";
-    File storageDir = Environment.getExternalStoragePublicDirectory(
-            Environment.DIRECTORY_PICTURES);
-    String galleryPath = storageDir.getAbsolutePath() + "/" + imageFileName;
-    return galleryPath;
-}
+    private String getPicutresPath()
+    {
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        String imageFileName = "IMG_" + timeStamp + ".jpg";
+        File storageDir = Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_PICTURES);
+        String galleryPath = storageDir.getAbsolutePath() + "/" + imageFileName;
+        return galleryPath;
+    }
 
-private void refreshGallery(Uri contentUri)
-{
-    Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-    mediaScanIntent.setData(contentUri);
-    this.cordova.getActivity().sendBroadcast(mediaScanIntent);
-}
+    private void refreshGallery(Uri contentUri)
+    {
+        Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+        mediaScanIntent.setData(contentUri);
+        this.cordova.getActivity().sendBroadcast(mediaScanIntent);
+    }
 
 
-private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
+    private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         // Create an ExifHelper to save the exif data that is lost during compression
         String modifiedPath = getTempDirectoryPath() + "/modified.jpg";
 
@@ -524,7 +615,7 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         return modifiedPath;
     }
 
-/**
+    /**
      * Applies all needed transformation to the image received from the gallery.
      *
      * @param destType          In which form should we return the image
@@ -621,7 +712,7 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
             }
         }
     }
-    
+
     /**
      * Called when the camera view exits.
      *
@@ -636,36 +727,38 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         int srcType = (requestCode / 16) - 1;
         int destType = (requestCode % 16) - 1;
 
-        // If Camera Crop
-        if (requestCode >= CROP_CAMERA) {
-            if (resultCode == Activity.RESULT_OK) {
+        // If the original activity was the source chooser, figure out the correct srcType and destType
+        if (requestCode >= SOURCE_CHOOSER) {
+            destType = requestCode - SOURCE_CHOOSER;
 
+            // Default to Camera, since that was the original reason the chooser was shown
+            srcType = CAMERA;
+            if (intent != null && !MediaStore.ACTION_IMAGE_CAPTURE.equals(intent.getAction()) && intent.getData() != null) {
+                srcType = PHOTOLIBRARY;
+            }
+
+            // Rewrite the requestCode
+            requestCode = (srcType + 1) * 16 + destType + 1;
+        }
+
+        // If the activity succeeded...
+        if (resultCode == Activity.RESULT_OK) {
+            // If this was a Camera Crop activity
+            if (requestCode >= CROP_CAMERA) {
                 // Because of the inability to pass through multiple intents, this hack will allow us
                 // to pass arcane codes back.
                 destType = requestCode - CROP_CAMERA;
                 try {
-                    processResultFromCamera(destType, intent);
+                     processResultFromCamera(destType, intent);
                 } catch (IOException e) {
                     e.printStackTrace();
                     Log.e(LOG_TAG, "Unable to write to file");
                 }
-
-            }// If cancelled
-            else if (resultCode == Activity.RESULT_CANCELED) {
-                this.failPicture("Camera cancelled.");
             }
-
-            // If something else
-            else {
-                this.failPicture("Did not complete!");
-            }
-        }
-        // If CAMERA
-        else if (srcType == CAMERA) {
-            // If image available
-            if (resultCode == Activity.RESULT_OK) {
+            // If this was a Camera activity
+            else if (srcType == CAMERA) {
                 try {
-                    if(this.allowEdit)
+                    if (this.allowEdit)
                     {
                         Uri tmpFile = Uri.fromFile(new File(getTempDirectoryPath(), ".Pic.jpg"));
                         performCrop(tmpFile, destType, intent);
@@ -678,28 +771,25 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
                     this.failPicture("Error capturing image.");
                 }
             }
-
-            // If cancelled
-            else if (resultCode == Activity.RESULT_CANCELED) {
-                this.failPicture("Camera cancelled.");
-            }
-
-            // If something else
-            else {
-                this.failPicture("Did not complete!");
+            // If retrieving photo from library
+            else if ((srcType == PHOTOLIBRARY) || (srcType == SAVEDPHOTOALBUM)) {
+                if (intent != null) {
+                    this.processResultFromGallery(destType, intent);
+                }
+                else {
+                    this.failPicture("Error selecting image.");
+                }
             }
         }
-        // If retrieving photo from library
-        else if ((srcType == PHOTOLIBRARY) || (srcType == SAVEDPHOTOALBUM)) {
-            if (resultCode == Activity.RESULT_OK && intent != null) {
-                this.processResultFromGallery(destType, intent);
-            }
-            else if (resultCode == Activity.RESULT_CANCELED) {
-                this.failPicture("Selection cancelled.");
-            }
-            else {
-                this.failPicture("Selection did not complete!");
-            }
+        // If the activity was cancelled...
+        else if (resultCode == Activity.RESULT_CANCELED) {
+            final String errMsg = (srcType == CAMERA || requestCode >= CROP_CAMERA) ? "Camera cancelled." : "Selection cancelled.";
+            this.failPicture(errMsg);
+        }
+        // Something else...
+        else {
+            final String errMsg = (srcType == CAMERA || requestCode >= CROP_CAMERA) ? "Did not complete!" : "Selection did not complete!";
+            this.failPicture(errMsg);
         }
     }
 
@@ -819,7 +909,7 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
      *
      * @param imagePath
      * @return
-     * @throws IOException 
+     * @throws IOException
      */
     private Bitmap getScaledBitmap(String imageUrl) throws IOException {
         // If no new width or height were specified return the original bitmap
@@ -863,7 +953,7 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         {
             return null;
         }
-        
+
         // determine the correct aspect ratio
         int[] widthHeight = calculateAspectRatio(options.outWidth, options.outHeight);
 

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -60,6 +60,8 @@ typedef NSUInteger CDVMediaType;
 @property (assign) BOOL usesGeolocation;
 @property (assign) BOOL cropToSize;
 
+@property (assign) BOOL showLibraryButton;
+
 + (instancetype) createFromTakePictureArguments:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -85,6 +85,9 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
     
+    // Only if source is Camera && opt set
+    pictureOptions.showLibraryButton = (pictureOptions.sourceType == UIImagePickerControllerSourceTypeCamera) &&
+        [[command argumentAtIndex:12 withDefault:@(NO)] boolValue];
     return pictureOptions;
 }
 
@@ -357,7 +360,7 @@ static NSString* toBase64(NSData* data) {
                         self.metadata = [[NSMutableDictionary alloc] init];
                         
                         NSMutableDictionary* EXIFDictionary = [[controllerMetadata objectForKey:(NSString*)kCGImagePropertyExifDictionary]mutableCopy];
-                        if (EXIFDictionary)	{
+                        if (EXIFDictionary) {
                             [self.metadata setObject:EXIFDictionary forKey:(NSString*)kCGImagePropertyExifDictionary];
                         }
                         
@@ -549,15 +552,15 @@ static NSString* toBase64(NSData* data) {
 
 - (CLLocationManager*)locationManager
 {
-	if (locationManager != nil) {
-		return locationManager;
-	}
+    if (locationManager != nil) {
+        return locationManager;
+    }
     
-	locationManager = [[CLLocationManager alloc] init];
-	[locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
-	[locationManager setDelegate:self];
+    locationManager = [[CLLocationManager alloc] init];
+    [locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
+    [locationManager setDelegate:self];
     
-	return locationManager;
+    return locationManager;
 }
 
 - (void)locationManager:(CLLocationManager*)manager didUpdateToLocation:(CLLocation*)newLocation fromLocation:(CLLocation*)oldLocation
@@ -708,7 +711,205 @@ static NSString* toBase64(NSData* data) {
         [self performSelector:sel withObject:nil afterDelay:0];
     }
     
+    if (self.pictureOptions.showLibraryButton) {
+        // Register for notifications when the user captures an image
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleNotification:) name:@"_UIImagePickerControllerUserDidCaptureItem"
+                                                   object:nil];
+        
+        // Register for notifications when the user returns to the camera view to take another picture
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleNotification:)
+                                                     name:@"_UIImagePickerControllerUserDidRejectItem"
+                                                   object:nil];
+    }
+   
     [super viewWillAppear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    if (self.pictureOptions.showLibraryButton) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+    }
+    
+    [super viewDidDisappear:animated];
+}
+
+- (void)handleNotification:(NSNotification*)notification {
+    if ([[notification name] isEqualToString:@"_UIImagePickerControllerUserDidCaptureItem"]) {
+        // Remove overlay, so that it is not available on the preview view;
+        [self.cameraOverlayView setHidden:YES];
+    }
+    else if ([[notification name] isEqualToString:@"_UIImagePickerControllerUserDidRejectItem"]) {
+        // Retake button pressed on preview. Add overlay, so that is available on the camera again
+        [self.cameraOverlayView setHidden:NO];
+    }
+}
+
+// Create an overlay view that include a button allowing quick access to choose an image from the library
+- (UIView*)createOverlayView {
+    UIView* overlay = [[UIView alloc] initWithFrame:self.view.bounds];
+    
+    // Make the background transparent so the existing UI shows through
+    overlay.opaque = NO;
+    overlay.backgroundColor = [UIColor clearColor];
+    
+    // Make sure the view auto-resizes when the orientation changes
+    overlay.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    
+    // Add a button to allow access to the camera roll
+    UIButton *libraryButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    libraryButton.backgroundColor = [UIColor clearColor];
+    
+    // For now, set the title to (localized) "Library" so it appears even if we can't get the most recent picture
+    [libraryButton setTitle:NSLocalizedString(@"Library", nil) forState:UIControlStateNormal];
+    libraryButton.imageView.contentMode = UIViewContentModeScaleAspectFill;
+    
+    [libraryButton addTarget:self
+                      action:@selector(switchToCameraRoll)
+            forControlEvents:UIControlEventTouchUpInside];
+    
+    [libraryButton setTranslatesAutoresizingMaskIntoConstraints:NO];
+
+    // Set the image to the most recent one in the Camera Roll
+    [self setImageFromCameraRoll:libraryButton];
+    
+    // Add the button to the overlay
+    [overlay addSubview:libraryButton];
+    
+    int rightOffset = 0;
+    NSLayoutConstraint *bottomConstraint;
+    
+    // Positioning for iPad
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        rightOffset = -21;
+        bottomConstraint = [NSLayoutConstraint constraintWithItem:libraryButton
+                                                        attribute:NSLayoutAttributeCenterY
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:overlay
+                                                        attribute:NSLayoutAttributeCenterY
+                                                       multiplier:1.5
+                                                         constant:0];
+    }
+    // Positioning for iPhone
+    else {
+        UIScreen* mainScreen = [UIScreen mainScreen];
+        CGFloat mainScreenHeight = mainScreen.bounds.size.height;
+        CGFloat mainScreenWidth = mainScreen.bounds.size.width;
+        
+        // On screens >480px tall, the controls are bigger
+        int limit = MAX(mainScreenHeight,mainScreenWidth);
+        int bottomOffset;
+        
+        // Determine the bottom offset based on the device screen size
+        switch (limit) {
+            case 480:
+            case 568:
+                bottomOffset = -7;
+                break;
+                
+            case 667:
+                bottomOffset = -18;
+                break;
+
+            case 736:
+            default:
+                bottomOffset = -27;
+                break;
+        
+        }
+
+        rightOffset = -13;
+        bottomConstraint = [NSLayoutConstraint constraintWithItem:libraryButton
+                                                        attribute:NSLayoutAttributeBottom
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:overlay
+                                                        attribute:NSLayoutAttributeBottom
+                                                       multiplier:1
+                                                         constant:bottomOffset];
+    }
+    
+    // Add auto-layout constraints to keep the size and position of the button correct on all devices
+    [overlay addConstraints:@[
+                              [NSLayoutConstraint constraintWithItem:libraryButton
+                                                           attribute:NSLayoutAttributeWidth
+                                                           relatedBy:NSLayoutRelationEqual
+                                                              toItem:nil
+                                                           attribute:NSLayoutAttributeNotAnAttribute
+                                                          multiplier:1.0
+                                                            constant:60.0],
+                              
+                              [NSLayoutConstraint constraintWithItem:libraryButton
+                                                           attribute:NSLayoutAttributeHeight
+                                                           relatedBy:NSLayoutRelationEqual
+                                                              toItem:nil
+                                                           attribute:NSLayoutAttributeNotAnAttribute
+                                                          multiplier:1.0
+                                                            constant:60.0],
+                              
+                              [NSLayoutConstraint constraintWithItem:libraryButton
+                                                           attribute:NSLayoutAttributeRight
+                                                           relatedBy:NSLayoutRelationEqual
+                                                              toItem:overlay
+                                                           attribute:NSLayoutAttributeRight
+                                                          multiplier:1
+                                                            constant:rightOffset],
+                              bottomConstraint
+                              ]];
+    
+    return overlay;
+}
+
+// Retrieves the last image from the camera roll, and sets it as the image for the library button
+- (void)setImageFromCameraRoll:(UIButton*)button {
+    // Make sure we have authorization to access it first, to avoid putting up an extra prompt right away
+    ALAuthorizationStatus status = [ALAssetsLibrary authorizationStatus];
+    
+    if (status != ALAuthorizationStatusAuthorized) {
+        return;
+    }
+    
+    // Enumerate the assets, take the first image, and set it on the UIButton
+    ALAssetsGroupEnumerationResultsBlock assetEnumBlock = ^(ALAsset *asset, NSUInteger index, BOOL *stop) {
+        if (!asset) return;
+        
+        ALAssetRepresentation *repr = [asset defaultRepresentation];
+        UIImage *img = [UIImage imageWithCGImage:[repr fullScreenImage]];
+        [button setImage:img forState:UIControlStateNormal];
+            
+        // Call this on the UI thread so it updates immediately
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [button setNeedsLayout];
+        });
+            
+        *stop = YES;
+    };
+
+    ALAssetsLibraryGroupsEnumerationResultsBlock groupsEnumBlock = ^(ALAssetsGroup *group, BOOL *stop) {
+        if (nil != group) {
+            // Filter the group to only include photos
+            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
+            
+            // Enumerate assets in reverse to get most recent
+            [group enumerateAssetsWithOptions:NSEnumerationReverse
+                                   usingBlock:assetEnumBlock];
+        }
+        
+        *stop = NO;
+    };
+    
+    // Enumerate the assets library
+    ALAssetsLibrary *assetsLibrary = [[ALAssetsLibrary alloc] init];
+    [assetsLibrary enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos
+                                 usingBlock:groupsEnumBlock
+                               failureBlock:^(NSError *error) {
+                                   NSLog(@"Camera: error enumerating library [%@]", error);
+                               }];
+}
+
+- (void)switchToCameraRoll {
+    // Switch the UIImagePickerController to show the saved photos album
+    self.sourceType = UIImagePickerControllerSourceTypeSavedPhotosAlbum;
 }
 
 + (instancetype) createFromPictureOptions:(CDVPictureOptions*)pictureOptions;
@@ -723,6 +924,12 @@ static NSString* toBase64(NSData* data) {
         cameraPicker.mediaTypes = @[(NSString*)kUTTypeImage];
         // We can only set the camera device if we're actually using the camera.
         cameraPicker.cameraDevice = pictureOptions.cameraDirection;
+        
+        // If enabled, show button to allow accessing library instead
+        // For iOS 7+ only, as the UI for lower versions is different
+        if (pictureOptions.showLibraryButton == YES && IsAtLeastiOSVersion(@"7.0")) {
+            cameraPicker.cameraOverlayView = [cameraPicker createOverlayView];
+        }
     } else if (pictureOptions.mediaType == MediaTypeAll) {
         cameraPicker.mediaTypes = [UIImagePickerController availableMediaTypesForSourceType:cameraPicker.sourceType];
     } else {

--- a/src/wp/Camera.cs
+++ b/src/wp/Camera.cs
@@ -119,13 +119,13 @@ namespace WPCordovaClassLib.Cordova.Commands
             [DataMember(IsRequired = false, Name = "allowEdit")]
             public bool AllowEdit { get; set; }
 
-                        /// <summary>
+            /// <summary>
             /// Height in pixels to scale image
             /// </summary>
             [DataMember(IsRequired = false, Name = "encodingType")]
             public int EncodingType { get; set; }
 
-                        /// <summary>
+            /// <summary>
             /// Height in pixels to scale image
             /// </summary>
             [DataMember(IsRequired = false, Name = "mediaType")]
@@ -138,12 +138,17 @@ namespace WPCordovaClassLib.Cordova.Commands
             [DataMember(IsRequired = false, Name = "targetHeight")]
             public int TargetHeight { get; set; }
 
-
             /// <summary>
             /// Width in pixels to scale image
             /// </summary>
             [DataMember(IsRequired = false, Name = "targetWidth")]
             public int TargetWidth { get; set; }
+
+            /// <summary>
+            /// Whether to allow moving between camera and library
+            /// </summary>
+            [DataMember(IsRequired = false, Name = "showLibraryButton")]
+            public bool ShowLibraryButton { get; set; }
 
             /// <summary>
             /// Creates options object with default parameters
@@ -169,6 +174,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 SaveToPhotoAlbum = false;
                 CorrectOrientation = true;
                 AllowEdit = false;
+                ShowLibraryButton = false;
                 MediaType = -1;
                 EncodingType = -1;
             }
@@ -185,7 +191,8 @@ namespace WPCordovaClassLib.Cordova.Commands
             {
                 string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
                 // ["quality", "destinationType", "sourceType", "targetWidth", "targetHeight", "encodingType",
-                //     "mediaType", "allowEdit", "correctOrientation", "saveToPhotoAlbum" ]
+                //     "mediaType", "allowEdit", "correctOrientation", "saveToPhotoAlbum", "popoverOptions",
+                //     "cameraDirection", "showLibraryButton"]
                 cameraOptions = new CameraOptions();
                 cameraOptions.Quality = int.Parse(args[0]);
                 cameraOptions.DestinationType = int.Parse(args[1]);
@@ -197,6 +204,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 cameraOptions.AllowEdit = bool.Parse(args[7]);
                 cameraOptions.CorrectOrientation = bool.Parse(args[8]);
                 cameraOptions.SaveToPhotoAlbum = bool.Parse(args[9]);
+                cameraOptions.ShowLibraryButton = bool.Parse(args[12]);
 
                 // a very large number will force the other value to be the bound
                 if (cameraOptions.TargetWidth > -1 && cameraOptions.TargetHeight == -1)
@@ -223,7 +231,19 @@ namespace WPCordovaClassLib.Cordova.Commands
             ChooserBase<PhotoResult> chooserTask = null;
             if (cameraOptions.PictureSourceType == CAMERA)
             {
-                chooserTask = new CameraCaptureTask();
+                // If the user requested to show the library button, then we will
+                // show the photo chooser with a camera button, as that's the closest
+                // we can get with the current WP Tasks.
+                if (cameraOptions.ShowLibraryButton)
+                {
+                    PhotoChooserTask task = new PhotoChooserTask();
+                    task.ShowCamera = true;
+                    chooserTask = task;
+                }
+                else
+                {
+                    chooserTask = new CameraCaptureTask();
+                }
             }
             else if ((cameraOptions.PictureSourceType == PHOTOLIBRARY) || (cameraOptions.PictureSourceType == SAVEDPHOTOALBUM))
             {

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -59,9 +59,10 @@ cameraExport.getPicture = function(successCallback, errorCallback, options) {
     var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     var popoverOptions = getValue(options.popoverOptions, null);
     var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    var showLibraryButton = !!options.showLibraryButton;
 
     var args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-                mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+                mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, showLibraryButton];
 
     exec(successCallback, errorCallback, "Camera", "takePicture", args);
     // XXX: commented out


### PR DESCRIPTION
A new camera option, showLibraryButton, is added which allows the user
to easily switch from the camera to the photo library once they have
entered the plugin.

Currently, this is optimally supported on iOS (7+), with additional
implementations for Android and WP8 based on what was available for
those platforms.
